### PR TITLE
Add /api prefix to all console API routes

### DIFF
--- a/console/app.py
+++ b/console/app.py
@@ -126,10 +126,10 @@ app = FastAPI(
 )
 
 # Include routers
-app.include_router(clusters.router)
-app.include_router(deployments.router)
-app.include_router(nodes.router)
-app.include_router(monitoring.router)
+app.include_router(clusters.router, prefix="/api")
+app.include_router(deployments.router, prefix="/api")
+app.include_router(nodes.router, prefix="/api")
+app.include_router(monitoring.router, prefix="/api")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Adds `/api` prefix to all router includes in `console/app.py`

Closes #4

## Test plan

- [ ] `GET /api/clusters` returns 200
- [ ] `GET /api/nodes` returns 200
- [ ] Swagger UI at `/docs` reflects updated paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)