### PR TITLE
Opt into Node.js 24 for GitHub Actions runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 permissions:
   contents: write
 


### PR DESCRIPTION
## Summary

- Adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to the workflow env in `.github/workflows/release.yml`

Closes #6

## Test plan

- [ ] Release workflow runs without Node.js 20 deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)