### PR TITLE
Fix start-all treating falsy agent response as failure

### DIFF
--- a/console/api/clusters.py
+++ b/console/api/clusters.py
@@ -267,11 +267,12 @@ async def start_all(cluster_id: str) -> Dict[str, Any]:
             continue
 
         result = await node_manager.send_command(node_id, cluster.app_id, "start")
-        if result:
+        if result is not None:
             results.append({"node_id": node_id, "status": "started"})
             started += 1
         else:
             results.append({"node_id": node_id, "status": "error", "error": "Agent unreachable"})
+            # Continue to next node to compensate for this failure
 
     return {
         "cluster_id": cluster_id,


### PR DESCRIPTION
## Summary

- Change `if result:` to `if result is not None:` in `start_all` so a valid but empty dict response from an agent is correctly counted as a started instance
- Failed nodes already fell through via `continue` — the loop correctly compensates by attempting subsequent nodes to reach `min_instances`

Closes #13

## Test plan

- [ ] `POST /api/clusters/{cluster_id}/start-all` starts the correct number of instances when some nodes return empty responses
- [ ] Failed nodes (agent unreachable) are skipped and subsequent nodes are attempted

🤖 Generated with [Claude Code](https://claude.com/claude-code)