### PR TITLE
fix: ensure frontend dir exists before copying dist in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,7 @@ jobs:
           VERSION="${{ steps.version.outputs.VERSION }}"
           PKG="tcm-${VERSION}"
           mkdir -p "${PKG}"
+          mkdir -p "${PKG}/frontend"
 
           # Copy application code
           cp -r console/ "${PKG}/console/"


### PR DESCRIPTION
This PR fixes the release workflow so it creates the frontend directory before copying the built dist folder, preventing cp errors if the directory does not exist.\n\nCloses #17.